### PR TITLE
use slug in url path instead of db id

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # UrlGrey, Picard's favorite URL shortener
+### v 0.1.1
 
 ![tea, earl grey, hot!](picard-tea.gif)
 
@@ -9,6 +10,8 @@
 ## About
 
 UrlGrey is a URL shortener written in Rails 5, backed by PostGres (or whatever you want, just change `database.yml`). The best part is its ability to redirect the root URL to allow for a bare domain vanity URL (try hitting https://grz.li and see where it takes you!).
+
+[Changelog](changelog).
 
 ## Setup
 

--- a/app/controllers/short_urls_controller.rb
+++ b/app/controllers/short_urls_controller.rb
@@ -11,7 +11,7 @@ class ShortUrlsController < ApplicationController
   end
 
   def show
-    @short_url = ShortUrl.find(params[:id])
+    @short_url = ShortUrl.find_by(slug: params[:slug])
   end
 
   def new
@@ -29,11 +29,11 @@ class ShortUrlsController < ApplicationController
   end
 
   def edit
-    @short_url = ShortUrl.find(params[:id])
+    @short_url = ShortUrl.find_by(slug: params[:slug])
   end
 
   def update
-    @short_url = ShortUrl.find(params[:id])
+    @short_url = ShortUrl.find_by(slug: params[:slug])
     if @short_url.update_attributes(short_url_params)
       flash[:success] = "#{@short_url.slug} updated successfully."
       redirect_to short_urls_path
@@ -43,11 +43,11 @@ class ShortUrlsController < ApplicationController
   end
 
   def delete
-    @short_url = ShortUrl.find(params[:id])
+    @short_url = ShortUrl.find_by(slug: params[:slug])
   end
 
   def destroy
-    @short_url = ShortUrl.find(params[:id])
+    @short_url = ShortUrl.find_by(slug: params[:slug])
     @short_url.destroy
     flash[:success] = "Short URL '#{@short_url.slug} has been deleted."
     redirect_to short_urls_path
@@ -57,7 +57,11 @@ class ShortUrlsController < ApplicationController
 
   # Strengthens parameters
   def short_url_params
-    params.require(:short_url).permit(:slug, :redirect)
+    if ShortUrl.find_by(slug: params[:slug]) # Only permit redirect editing if the short URL exists
+      params.require(:short_url).permit(:redirect)
+    else
+      params.require(:short_url).permit(:slug, :redirect)
+    end
   end
 
   # Performs search or reverse search based on request

--- a/app/models/short_url.rb
+++ b/app/models/short_url.rb
@@ -26,11 +26,19 @@ class ShortUrl < ApplicationRecord
   before_save :ensure_scheme
 
   ###### Public methods ########################
+
+  # Sets up short URL slugs to be used as params in routing
+  def to_param
+    slug
+  end
+  
   class << self
+    # Searches for short URL by slug
     def search(search)
       ShortUrl.where("slug ILIKE ?", "%#{search}%")
     end
 
+    # Searches for short URLs by redirect
     def reverse_search(search)
       where("redirect ILIKE ?", "%#{search}%")
     end

--- a/app/views/short_urls/edit.html.erb
+++ b/app/views/short_urls/edit.html.erb
@@ -1,3 +1,13 @@
 <%= provide(:title, "Edit #{@short_url.slug}") %>
 
-<%= render 'form' %>
+<%= form_for(@short_url) do |f| %>
+  <%= render partial: 'shared/error_messages', locals: { object: @short_url } %>
+
+  <h3>Change the redirect for <%= @short_url.slug %></h3>
+
+  <%= f.label :redirect, 'Redirecting to' %>
+  <%= f.url_field :redirect %>
+
+  <%= f.submit 'Save changes', class: 'button large' %>
+<% end %><!-- end `form_for(@short_url)` -->
+

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,10 @@
+# Url Grey changelog
+
+## v 0.1.1
+
+- Change Short URL resource to use short URL slugs in the URL as the parameter instead of the database ID
+- Change Short URL resource paths to display 'short-url' instead of 'short_url'
+
+## v 0.1
+
+Initial release.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
 
   scope '/admin' do
     resources :users
-    resources :short_urls do
+    resources :short_urls, param: :slug, path: 'short-urls' do
       get 'search', on: :collection
     end
   end


### PR DESCRIPTION
Changes the routes and short URLs controller to display the short URL's slug in the path instead of the DB id. This enables easy-edits via URL for logged in users.