### PR TITLE
reserves application domain from redirection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ gem 'jbuilder',                  '~> 2.5'
 
 # Use Radix for base-37 conversions
 gem 'radix'
+# Use Addressable for URL parsing without schemes
+gem 'addressable'
 
 # Use Rails Settings for in-app configurable settings
 gem "rails-settings-cached"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,6 +239,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  addressable
   bcrypt (~> 3.1.11)
   bundler (~> 1.15.0)
   byebug

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # UrlGrey, Picard's favorite URL shortener
-### v 0.1.2
+### v 0.1.3
 
 ![tea, earl grey, hot!](picard-tea.gif)
 
@@ -31,7 +31,13 @@ If you want to reserve any URL slugs from use, do so in `config/initializers/res
 
 ### Configuration
 
-The app has some basic configurations that can/should be set in `config/application.rb` before deploying it for yourself. Currently, this is just to enable the special root url redirect, and to rename the application to suit your own tastes. Maybe you prefer coffee, and have some awesome coffee/URL pun instead of 'Url Grey'?
+The app has some basic configurations that should be set in `config/application.rb` before deploying it for yourself. Currently, this is just to enable the special root url redirect, and to rename the application to suit your own tastes. Maybe you prefer coffee, and have some awesome coffee/URL pun instead of 'Url Grey'?
+
+#### Required:
+
+- Set the application host: `config.application_host = 'https://your.domain'
+
+#### Optional
 
 - To rename the application, change: `config.application_name = 'URL Grey'`
 - To configure the root redirect, before deploying the app, change the first `ShortUrl` seed's redirect value
@@ -73,7 +79,7 @@ To change this, first, mess around with the `before_action` filters in `users_co
   - [x] redirection
 - [x] URL search and reverse search for checking if a short URL destination already exists, or if a slug is taken
 - [ ] move search into its own controller so results don't appear behind the `/admin` path (because they're visible to anonymous users)
-- [ ] disallow the applications own domain as a redirection destination (hello infinite loop!)
+- [x] disallow the applications own domain as a redirection destination (hello infinite loop!)
 - [ ] displaying short URL stats
   - [ ] number of hits
     - [ ] overall

--- a/app/controllers/short_urls_controller.rb
+++ b/app/controllers/short_urls_controller.rb
@@ -49,7 +49,7 @@ class ShortUrlsController < ApplicationController
   def destroy
     @short_url = ShortUrl.find_by(slug: params[:slug])
     @short_url.destroy
-    flash[:success] = "Short URL '#{@short_url.slug} has been deleted."
+    flash[:success] = "Short URL '#{@short_url.slug}' has been deleted."
     redirect_to short_urls_path
   end
 

--- a/app/models/short_url.rb
+++ b/app/models/short_url.rb
@@ -27,9 +27,10 @@ class ShortUrl < ApplicationRecord
                    length:     { maximum: 255 },
                    slug:       true
 
-  validates :redirect,  presence: true,
-                        length:   { maximum: 300 },
-                        url:      true
+  validates :redirect,  presence:      true,
+                        length:        { maximum: 300 },
+                        url:           true,
+                        safe_redirect: true
 
 
 

--- a/app/validators/safe_redirect_validator.rb
+++ b/app/validators/safe_redirect_validator.rb
@@ -1,0 +1,21 @@
+# Validates URLs
+class SafeRedirectValidator < ActiveModel::EachValidator
+  require 'addressable'
+
+  def validate_each(record, attribute, value)
+    return if validate_safe_redirect(value)
+    record.errors.add(attribute, (options[:message] || :redirecting_to_app_host))
+  end
+
+  private
+
+  def validate_safe_redirect(value)
+    # Blacklist currently consists of just the application domain
+    app_host = URI.parse(UrlGrey::Application.config.application_host).host
+
+    redirect = Addressable::URI.heuristic_parse(value)
+    redirect.host != app_host
+  rescue
+    false
+  end
+end 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Url Grey changelog
 
+## v 0.1.3
+
+- Protect the application's own domain from being redirected to, to avoid possible infinite loops or inaccessible application routes
+
 ## v 0.1.2
 
 - Add random slug generator for new short URLs

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,7 @@ module UrlGrey
 
     # Customize your application's name
     config.application_name = 'URL Grey'
+    config.application_host = 'https://grz.li'
 
     # Optionally set '/' as a short URL. This will only have effect
     ## if the app can find a ShortUrl with slug 'root' to redirect to

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,11 +34,13 @@ en:
     errors:
       messages:
         url_format: "'%{value}' is not a valid URL"
-        slug_format: "'%{value}' is not available as a short URL slug."
+        redirecting_to_app_host: "'%{value}' is not a permissible redirect"
+        slug_format: "'%{value}' is not available as a short URL slug"
       models:
         short_url:
           attributes:
             redirect:
               url_format: "'%{value}' is not a valid URL"
+              redirecting_to_app_host: "'%{value}' is not a permissible redirect"
             slug:
-              slug_format: "'%{value}' is not available as a short URL slug."
+              slug_format: "'%{value}' is not available as a short URL slug"

--- a/test/models/short_url_test.rb
+++ b/test/models/short_url_test.rb
@@ -199,4 +199,23 @@ class ShortUrlTest < ActiveSupport::TestCase
       assert_not ShortUrl.random_slug(2).include?('-')
     end
   end
+
+  test 'cannot redirect to application host' do
+    # Temporarily unset the application host value
+    # so tests remain agnostic of installation
+    real_app_host = UrlGrey::Application.config.application_host
+    UrlGrey::Application.config.application_host = 'http://www.google.com'
+
+    short_url = ShortUrl.new(slug: 'uh-oh', redirect: 'http://www.google.com')
+    assert_not short_url.valid?
+
+    short_url = ShortUrl.new(slug: 'still-bad', redirect: 'https://www.google.com')
+    assert_not short_url.valid?
+
+    short_url = ShortUrl.new(slug: 'really-still-not-ok', redirect: 'www.google.com')
+    assert_not short_url.valid?
+
+    # Reset the application host so tests are not order dependent
+    UrlGrey::Application.config.application_host = real_app_host
+  end
 end


### PR DESCRIPTION
adds a custom validator to check redirects are safe. Could in theory b
expanded to check other hosts than the application host by
defining a set of blacklisted domains for redirection,
and updating the validator to check them all.